### PR TITLE
Update visualization property names to fit emission calculation result field naming

### DIFF
--- a/docs/visualizations_SLD/co2_emissions.sld
+++ b/docs/visualizations_SLD/co2_emissions.sld
@@ -13,11 +13,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>0.98999999999999999</ogc:Literal>
               </ogc:PropertyIsGreaterThanOrEqualTo>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>600</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -41,11 +41,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>600</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>1200</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -69,11 +69,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>1200</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>2000</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -97,11 +97,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>2000</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>4000</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -125,11 +125,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>4000</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>8000</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -153,11 +153,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>8000</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>summa</ogc:PropertyName>
+                <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
                 <ogc:Literal>12138.58357400000022608</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -178,7 +178,7 @@
           <se:MaxScaleDenominator>25000</se:MaxScaleDenominator>
           <se:TextSymbolizer>
             <se:Label>
-              <ogc:PropertyName>summa</ogc:PropertyName>
+              <ogc:PropertyName>sum_yhteensa_tco2</ogc:PropertyName>
             </se:Label>
             <se:Font>
               <se:SvgParameter name="font-family">Arial</se:SvgParameter>

--- a/docs/visualizations_SLD/population.sld
+++ b/docs/visualizations_SLD/population.sld
@@ -13,11 +13,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>1</ogc:Literal>
               </ogc:PropertyIsGreaterThanOrEqualTo>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>10</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -48,11 +48,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>10</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>50</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -87,11 +87,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>50</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>100</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -122,11 +122,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>100</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>500</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>
@@ -157,11 +157,11 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>500</ogc:Literal>
               </ogc:PropertyIsGreaterThan>
               <ogc:PropertyIsLessThanOrEqualTo>
-                <ogc:PropertyName>v_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_vaesto</ogc:PropertyName>
                 <ogc:Literal>1366</ogc:Literal>
               </ogc:PropertyIsLessThanOrEqualTo>
             </ogc:And>

--- a/docs/visualizations_SLD/top_emission_source_per_grid_cell.sld
+++ b/docs/visualizations_SLD/top_emission_source_per_grid_cell.sld
@@ -13,30 +13,18 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:And>
-                <ogc:And>
-                  <ogc:And>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                      <ogc:PropertyName>vesi_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                      <ogc:PropertyName>jaahdytys_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                  </ogc:And>
-                  <ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                    <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                  </ogc:PropertyIsGreaterThan>
-                </ogc:And>
                 <ogc:PropertyIsGreaterThan>
-                  <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                  <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
+                  <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
                 </ogc:PropertyIsGreaterThan>
               </ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
               </ogc:PropertyIsGreaterThan>
             </ogc:And>
           </ogc:Filter>
@@ -65,30 +53,18 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:And>
-                <ogc:And>
-                  <ogc:And>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                      <ogc:PropertyName>vesi_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                      <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                  </ogc:And>
-                  <ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                    <ogc:PropertyName>jaahdytys_tco2</ogc:PropertyName>
-                  </ogc:PropertyIsGreaterThan>
-                </ogc:And>
                 <ogc:PropertyIsGreaterThan>
-                  <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                  <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
+                  <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
                 </ogc:PropertyIsGreaterThan>
               </ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>sahko_yht</ogc:PropertyName>
-                <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
               </ogc:PropertyIsGreaterThan>
             </ogc:And>
           </ogc:Filter>
@@ -113,30 +89,18 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:And>
-                <ogc:And>
-                  <ogc:And>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
-                      <ogc:PropertyName>vesi_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
-                      <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                  </ogc:And>
-                  <ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
-                    <ogc:PropertyName>jaahdytys_tco2</ogc:PropertyName>
-                  </ogc:PropertyIsGreaterThan>
-                </ogc:And>
                 <ogc:PropertyIsGreaterThan>
-                  <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
-                  <ogc:PropertyName>sahko_yht</ogc:PropertyName>
+                  <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
                 </ogc:PropertyIsGreaterThan>
               </ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
-                <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
               </ogc:PropertyIsGreaterThan>
             </ogc:And>
           </ogc:Filter>
@@ -165,30 +129,18 @@
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:And>
               <ogc:And>
-                <ogc:And>
-                  <ogc:And>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
-                      <ogc:PropertyName>vesi_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyIsGreaterThan>
-                      <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
-                      <ogc:PropertyName>lammitys_tco2</ogc:PropertyName>
-                    </ogc:PropertyIsGreaterThan>
-                  </ogc:And>
-                  <ogc:PropertyIsGreaterThan>
-                    <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
-                    <ogc:PropertyName>jaahdytys_tco2</ogc:PropertyName>
-                  </ogc:PropertyIsGreaterThan>
-                </ogc:And>
                 <ogc:PropertyIsGreaterThan>
-                  <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
-                  <ogc:PropertyName>sahko_yht</ogc:PropertyName>
+                  <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_lammonsaato_tco2</ogc:PropertyName>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
+                  <ogc:PropertyName>sum_sahko_tco2</ogc:PropertyName>
                 </ogc:PropertyIsGreaterThan>
               </ogc:And>
               <ogc:PropertyIsGreaterThan>
-                <ogc:PropertyName>korjaussaneeraus_tco2</ogc:PropertyName>
-                <ogc:PropertyName>liikenne_yht</ogc:PropertyName>
+                <ogc:PropertyName>sum_rakentaminen_tco2</ogc:PropertyName>
+                <ogc:PropertyName>sum_liikenne_tco2</ogc:PropertyName>
               </ogc:PropertyIsGreaterThan>
             </ogc:And>
           </ogc:Filter>


### PR DESCRIPTION
You might wish to consider YKR population field name because SYKE data uses v_yht field name. On the other hand, sum_vaesto follows naming of the CO2 sum field names in the emission calculation.